### PR TITLE
Fix Notion image caching with build-time asset sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ yarn-error.log*
 # TypeScript build cache
 tsconfig.tsbuildinfo
 
+# generated Notion asset cache + manifest
+/public/notion-assets
+/src/generated/notion-asset-manifest.json
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,9 +19,23 @@
 - Notion database with properties: Title, Slug, Status, Date, Excerpt
 - Fetched server-side via `@notionhq/client` SDK v5
 - SDK v5 uses the `dataSources.query` API — the `data_source_id` is resolved at runtime from the database via `databases.retrieve`
-- Cached with `'use cache'`, `cacheLife('hours')`, and `cacheTag('writing')`
+- Cached with `'use cache'`, `cacheLife('max')`, and `cacheTag('writing')` — pages are built once and never re-fetched Notion between deploys
 - Block content rendered by `src/components/writing/render-blocks.tsx`
 - Data layer: `src/lib/notion/client.ts`, `types.ts`, `writing.ts`
+
+### Notion-hosted images
+
+Notion file URLs are signed S3 URLs that expire after ~1 hour. To keep the site
+truly static we download every referenced image at build time.
+
+- `scripts/sync-notion-assets.ts` runs as `prebuild` (Vercel build + `npm run build`)
+- Downloads all image/video/cover assets from writing, work, and TIL into `public/notion-assets/`
+- Emits `src/generated/notion-asset-manifest.json` (pathname → local path)
+- `src/lib/notion/localize-url.ts` rewrites Notion URLs via the manifest at render time
+- Fallback: if a URL is not in the manifest, the raw Notion URL is used (keeps `next dev` working before first sync)
+- Run `npm run sync-notion-assets` manually to refresh local dev images
+
+Both the manifest and `public/notion-assets/` are gitignored.
 
 ### Work (static)
 
@@ -46,9 +60,10 @@
 ### Caching
 
 - `'use cache'` directive on data-fetching functions (requires `cacheComponents: true` in `next.config.ts`)
-- `cacheLife('hours')` for Notion data
-- `cacheTag('writing')` for on-demand revalidation
+- `cacheLife('max')` for Notion data — pages are produced at build time and never re-fetch Notion between deploys
+- `cacheTag('writing' | 'work' | 'til')` for potential on-demand revalidation
 - `generateStaticParams` pre-renders published posts at build time
+- Likes are read live from Notion via `GET /api/likes/[slug]` on the client; the likes `POST` does NOT call `revalidateTag` (pages stay static; the client crossfades the fresh count on mount)
 
 ### Routing
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
+import './.next/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "prettier": "^3.8.1",
                 "prettier-plugin-tailwindcss": "^0.7.2",
                 "tailwindcss": "^4.2.1",
+                "tsx": "^4.21.0",
                 "typescript": "^5.9.3"
             }
         },
@@ -339,6 +340,448 @@
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -3224,6 +3667,48 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3897,6 +4382,21 @@
                 "react-dom": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/function-bind": {
@@ -6602,6 +7102,26 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/tsx": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.27.0",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
     "private": true,
     "scripts": {
         "dev": "next dev",
+        "prebuild": "tsx scripts/sync-notion-assets.ts",
         "build": "next build",
         "start": "next start",
         "lint": "eslint .",
         "format": "prettier --write .",
-        "format:check": "prettier --check ."
+        "format:check": "prettier --check .",
+        "sync-notion-assets": "tsx scripts/sync-notion-assets.ts"
     },
     "dependencies": {
         "@notionhq/client": "^5.13.0",
@@ -34,6 +36,7 @@
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.2.1",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3"
     }
 }

--- a/scripts/sync-notion-assets.ts
+++ b/scripts/sync-notion-assets.ts
@@ -1,0 +1,295 @@
+/**
+ * Downloads every Notion-hosted image referenced by published writing, work,
+ * and TIL pages into `public/notion-assets/` at build time and emits a manifest
+ * mapping stable Notion URL paths to the local asset paths.
+ *
+ * The runtime `localizeNotionUrl` helper rewrites URLs using this manifest so
+ * the site never depends on Notion's signed S3 URLs (which expire after ~1 h).
+ */
+
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import crypto from 'node:crypto'
+import { fileURLToPath } from 'node:url'
+import { loadEnvConfig } from '@next/env'
+import { Client } from '@notionhq/client'
+import type {
+    PageObjectResponse,
+    BlockObjectResponse,
+    PartialBlockObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+loadEnvConfig(rootDir)
+
+const PUBLIC_DIR = path.join(rootDir, 'public', 'notion-assets')
+const MANIFEST_PATH = path.join(
+    rootDir,
+    'src',
+    'generated',
+    'notion-asset-manifest.json'
+)
+
+const NOTION_HOST_PATTERNS = [
+    /(^|\.)notion-static\.com$/i,
+    /(^|\.)notion\.so$/i,
+    /(^|\.)notion\.site$/i,
+    /(^|\.)amazonaws\.com$/i,
+]
+
+type NotionUrl = { url: string; pathname: string }
+
+function requireEnv(name: string): string {
+    const value = process.env[name]
+    if (!value)
+        throw new Error(`Missing required environment variable: ${name}`)
+    return value
+}
+
+const notion = new Client({ auth: requireEnv('NOTION_TOKEN') })
+
+async function resolveDataSourceId(databaseId: string): Promise<string> {
+    const db = await notion.databases.retrieve({ database_id: databaseId })
+    const dataSources = (db as Record<string, unknown>).data_sources as
+        | Array<{ id: string }>
+        | undefined
+    if (!dataSources?.length) {
+        throw new Error(
+            `No data sources found on database ${databaseId}. ` +
+                'Ensure the database is shared with the integration.'
+        )
+    }
+    return dataSources[0].id
+}
+
+async function queryAllPages(
+    dataSourceId: string
+): Promise<PageObjectResponse[]> {
+    const results: PageObjectResponse[] = []
+    let cursor: string | undefined
+    do {
+        const response = await notion.dataSources.query({
+            data_source_id: dataSourceId,
+            start_cursor: cursor,
+            page_size: 100,
+        })
+        for (const page of response.results) {
+            if ('properties' in page) results.push(page as PageObjectResponse)
+        }
+        cursor = response.has_more
+            ? (response.next_cursor ?? undefined)
+            : undefined
+    } while (cursor)
+    return results
+}
+
+async function listAllBlocks(blockId: string): Promise<BlockObjectResponse[]> {
+    const blocks: BlockObjectResponse[] = []
+    let cursor: string | undefined
+    do {
+        const response = await notion.blocks.children.list({
+            block_id: blockId,
+            start_cursor: cursor,
+            page_size: 100,
+        })
+        for (const block of response.results as Array<
+            BlockObjectResponse | PartialBlockObjectResponse
+        >) {
+            if (!('type' in block)) continue
+            blocks.push(block)
+            if (block.has_children) {
+                const children = await listAllBlocks(block.id)
+                blocks.push(...children)
+            }
+        }
+        cursor = response.has_more
+            ? (response.next_cursor ?? undefined)
+            : undefined
+    } while (cursor)
+    return blocks
+}
+
+function isNotionHostedUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url)
+        if (parsed.searchParams.has('X-Amz-Signature')) return true
+        return NOTION_HOST_PATTERNS.some((pattern) =>
+            pattern.test(parsed.hostname)
+        )
+    } catch {
+        return false
+    }
+}
+
+function extractCoverImageUrl(page: PageObjectResponse): string | null {
+    const cover = page.properties.CoverImage
+    if (!cover || cover.type !== 'files' || cover.files.length === 0)
+        return null
+    const file = cover.files[0]
+    if (file.type === 'external') return file.external.url
+    if (file.type === 'file') return file.file.url
+    return null
+}
+
+function extractBlockUrls(block: BlockObjectResponse): string[] {
+    const urls: string[] = []
+    if (block.type === 'image') {
+        urls.push(
+            block.image.type === 'external'
+                ? block.image.external.url
+                : block.image.file.url
+        )
+    } else if (block.type === 'video') {
+        urls.push(
+            block.video.type === 'external'
+                ? block.video.external.url
+                : block.video.file.url
+        )
+    } else if (block.type === 'file') {
+        urls.push(
+            block.file.type === 'external'
+                ? block.file.external.url
+                : block.file.file.url
+        )
+    }
+    return urls
+}
+
+function toStableKey(url: string): NotionUrl | null {
+    try {
+        const { pathname } = new URL(url)
+        return { url, pathname }
+    } catch {
+        return null
+    }
+}
+
+function extFor(pathname: string): string {
+    const ext = path.extname(pathname).toLowerCase()
+    if (ext && ext.length <= 6) return ext
+    return '.bin'
+}
+
+function hashFor(pathname: string): string {
+    return crypto
+        .createHash('sha256')
+        .update(pathname)
+        .digest('hex')
+        .slice(0, 16)
+}
+
+async function download(url: string, dest: string): Promise<void> {
+    const response = await fetch(url)
+    if (!response.ok) {
+        throw new Error(
+            `Failed to download ${url}: ${response.status} ${response.statusText}`
+        )
+    }
+    const buffer = Buffer.from(await response.arrayBuffer())
+    await fs.writeFile(dest, buffer)
+}
+
+async function fileExists(p: string): Promise<boolean> {
+    try {
+        await fs.stat(p)
+        return true
+    } catch {
+        return false
+    }
+}
+
+async function collectNotionUrls(): Promise<NotionUrl[]> {
+    const writingDbId = requireEnv('NOTION_WRITING_DB_ID')
+    const workDbId = requireEnv('NOTION_WORK_DB_ID')
+    const tilDbId = requireEnv('NOTION_TIL_DB_ID')
+
+    const [writingDs, workDs, tilDs] = await Promise.all([
+        resolveDataSourceId(writingDbId),
+        resolveDataSourceId(workDbId),
+        resolveDataSourceId(tilDbId),
+    ])
+
+    const [writingPages, workPages, tilPages] = await Promise.all([
+        queryAllPages(writingDs),
+        queryAllPages(workDs),
+        queryAllPages(tilDs),
+    ])
+
+    const allPages = [...writingPages, ...workPages, ...tilPages]
+
+    const seen = new Map<string, NotionUrl>()
+    const rawUrls: string[] = []
+
+    for (const page of workPages) {
+        const cover = extractCoverImageUrl(page)
+        if (cover) rawUrls.push(cover)
+    }
+
+    for (const page of allPages) {
+        const blocks = await listAllBlocks(page.id)
+        for (const block of blocks) rawUrls.push(...extractBlockUrls(block))
+    }
+
+    for (const raw of rawUrls) {
+        if (!isNotionHostedUrl(raw)) continue
+        const entry = toStableKey(raw)
+        if (!entry) continue
+        if (!seen.has(entry.pathname)) seen.set(entry.pathname, entry)
+    }
+
+    return Array.from(seen.values())
+}
+
+async function sync(): Promise<void> {
+    await fs.mkdir(PUBLIC_DIR, { recursive: true })
+    await fs.mkdir(path.dirname(MANIFEST_PATH), { recursive: true })
+
+    console.log('Collecting Notion-hosted URLs from writing, work, and TIL...')
+    const urls = await collectNotionUrls()
+    console.log(`Found ${urls.length} unique Notion-hosted asset(s)`)
+
+    const manifest: Record<string, string> = {}
+    let downloaded = 0
+    let skipped = 0
+
+    for (const { url, pathname } of urls) {
+        const hash = hashFor(pathname)
+        const ext = extFor(pathname)
+        const filename = `${hash}${ext}`
+        const localPath = `/notion-assets/${filename}`
+        const dest = path.join(PUBLIC_DIR, filename)
+
+        if (await fileExists(dest)) {
+            skipped++
+        } else {
+            try {
+                await download(url, dest)
+                downloaded++
+                console.log(`  downloaded ${filename}`)
+            } catch (err) {
+                console.warn(`  skipped ${filename}:`, (err as Error).message)
+                continue
+            }
+        }
+        manifest[pathname] = localPath
+    }
+
+    const sortedManifest: Record<string, string> = {}
+    for (const key of Object.keys(manifest).sort()) {
+        sortedManifest[key] = manifest[key]
+    }
+
+    await fs.writeFile(
+        MANIFEST_PATH,
+        JSON.stringify(sortedManifest, null, 2) + '\n'
+    )
+
+    console.log(
+        `Manifest written with ${Object.keys(sortedManifest).length} entries (${downloaded} downloaded, ${skipped} cached)`
+    )
+}
+
+sync().catch((err) => {
+    console.error('sync-notion-assets failed:', err)
+    process.exit(1)
+})

--- a/src/app/api/likes/[slug]/route.ts
+++ b/src/app/api/likes/[slug]/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server'
-import { revalidateTag } from 'next/cache'
 import { notion } from '@/lib/notion/client'
 import { getWritingDbId, getTilDbId } from '@/lib/notion/config'
 import { resolveDataSourceId } from '@/lib/notion/resolve-data-source-id'
@@ -9,10 +8,6 @@ type ContentType = 'writing' | 'til'
 
 function getDbId(type: ContentType): string {
     return type === 'til' ? getTilDbId() : getWritingDbId()
-}
-
-function getCacheTagPrefix(type: ContentType): string {
-    return type === 'til' ? 'til' : 'writing'
 }
 
 function parseType(request: Request): ContentType {
@@ -114,10 +109,6 @@ export async function POST(
                 Likes: { number: newTotal },
             },
         })
-
-        const prefix = getCacheTagPrefix(type)
-        revalidateTag(prefix, 'max')
-        revalidateTag(`${prefix}:${slug}`, 'max')
 
         return NextResponse.json({ likes: newTotal })
     } catch (e) {

--- a/src/components/writing/render-blocks.tsx
+++ b/src/components/writing/render-blocks.tsx
@@ -17,6 +17,7 @@ import type {
 import { inlineLinkClass } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 import type { NotionBlock } from '@/lib/notion/types'
+import { localizeNotionUrl } from '@/lib/notion/localize-url'
 
 export function renderBlocks(blocks: NotionBlock[]) {
     const elements: React.ReactNode[] = []
@@ -108,10 +109,11 @@ function Block({ block }: { block: NotionBlock }) {
         }
         case 'image': {
             const b = block as ImageBlockObjectResponse
-            const src =
+            const rawImageSrc =
                 b.image.type === 'external'
                     ? b.image.external.url
                     : b.image.file.url
+            const src = localizeNotionUrl(rawImageSrc)
             const caption = b.image.caption?.[0]?.plain_text ?? ''
             return (
                 <figure>
@@ -135,7 +137,8 @@ function Block({ block }: { block: NotionBlock }) {
                 b.video.type === 'external'
                     ? b.video.external.url
                     : b.video.file.url
-            const src = getEmbeddableUrl(rawSrc)
+            const localized = localizeNotionUrl(rawSrc)
+            const src = getEmbeddableUrl(localized)
             const caption = b.video.caption?.[0]?.plain_text ?? ''
             const isEmbed = /^https?:\/\//.test(src)
 

--- a/src/lib/notion/localize-url.ts
+++ b/src/lib/notion/localize-url.ts
@@ -1,0 +1,21 @@
+import manifest from '@/generated/notion-asset-manifest.json'
+
+const assetManifest = manifest as Record<string, string>
+
+// Rewrites Notion-hosted URLs to locally downloaded assets when a match exists
+// in the build-time manifest. Falls back to the original URL so local dev works
+// without running the sync script first (raw Notion URLs are valid for ~1 hour).
+export function localizeNotionUrl(url: string): string
+export function localizeNotionUrl(url: null | undefined): null
+export function localizeNotionUrl(url: string | null | undefined): string | null
+export function localizeNotionUrl(
+    url: string | null | undefined
+): string | null {
+    if (!url) return null
+    try {
+        const { pathname } = new URL(url)
+        return assetManifest[pathname] ?? url
+    } catch {
+        return url
+    }
+}

--- a/src/lib/notion/work.ts
+++ b/src/lib/notion/work.ts
@@ -4,6 +4,7 @@ import { notion } from './client'
 import { getWorkDbId } from './config'
 import { resolveDataSourceId } from './resolve-data-source-id'
 import { listPageBlocks } from './list-page-blocks'
+import { localizeNotionUrl } from './localize-url'
 import type {
     PageObjectResponse,
     WorkItem,
@@ -20,7 +21,7 @@ async function getDataSourceId(): Promise<string> {
 
 export async function getWorkItems(): Promise<WorkMeta[]> {
     'use cache'
-    cacheLife('hours')
+    cacheLife('max')
     cacheTag('work')
 
     const dataSourceId = await getDataSourceId()
@@ -40,7 +41,7 @@ export async function getWorkItems(): Promise<WorkMeta[]> {
 
 export async function getWorkItem(slug: string): Promise<WorkItem | null> {
     'use cache'
-    cacheLife('hours')
+    cacheLife('max')
     cacheTag('work', `work:${slug}`)
 
     try {
@@ -170,8 +171,8 @@ function getCoverImage(
     }
 
     const file = property.files[0]
-    if (file.type === 'external') return file.external.url
-    if (file.type === 'file') return file.file.url
+    if (file.type === 'external') return localizeNotionUrl(file.external.url)
+    if (file.type === 'file') return localizeNotionUrl(file.file.url)
     return null
 }
 

--- a/src/lib/notion/writing.ts
+++ b/src/lib/notion/writing.ts
@@ -12,7 +12,7 @@ async function getDataSourceId(): Promise<string> {
 
 export async function getWritingPosts(): Promise<PostMeta[]> {
     'use cache'
-    cacheLife('hours')
+    cacheLife('max')
     cacheTag('writing')
 
     const dataSourceId = await getDataSourceId()
@@ -32,7 +32,7 @@ export async function getWritingPosts(): Promise<PostMeta[]> {
 
 export async function getWritingPost(slug: string): Promise<Post | null> {
     'use cache'
-    cacheLife('minutes')
+    cacheLife('max')
     cacheTag('writing', `writing:${slug}`)
 
     try {


### PR DESCRIPTION
## Summary

Notion file URLs are signed S3 URLs that expire after ~1 hour, which was breaking cover images and inline images across work, writing, and TIL pages whenever the cached page outlived the signature. This PR makes the site truly static with no runtime dependency on Notion image URLs.

- Download every Notion-hosted image/video/cover asset at build time via a new `prebuild` script (`scripts/sync-notion-assets.ts`) into `public/notion-assets/` and emit a manifest keyed by the stable URL pathname
- Rewrite image URLs at render via a small `localizeNotionUrl` helper, applied to work cover images and the image/video block renderer
- Switch writing/work `cacheLife` to `'max'` so pages never re-fetch Notion between deploys (TIL was already `'max'`)
- Drop `revalidateTag` from the likes `POST`; `LikeButton` already fetches the current count on mount, so page rendering no longer needs to refresh when likes change
- Keeps Notion as the CMS; updating content = redeploy

## Test plan

- [x] Local: `npm run build && npm start` — open `/work`, a few `/work/[slug]`, `/writing/[slug]`, `/til`; images load from `/notion-assets/...` (verify via DevTools Network)
- [x] Local: click a like button, count increments and persists after reload
- [x] Preview deploy: all images load immediately
- [x] Preview deploy: `view-source:` on a case study shows `<img src="/notion-assets/...">` (no `prod-files.secure.notion-static.com` references)
- [x] **Preview deploy: revisit 60+ minutes later — images still load** (this is the real regression test for signed-URL expiry)
- [x] Preview deploy: like counter still increments via `POST /api/likes/[slug]` and `GET` returns the live number
- [x] Edit a Notion post between builds; the preview does NOT re-fetch on visit (pages stay static); the next redeploy picks up the change

## Notes

- `public/notion-assets/` and `src/generated/notion-asset-manifest.json` are gitignored; they regenerate on every build
- Adds `tsx` as a devDependency
- `docs/architecture.md` updated to describe the new build step and caching model
