### PR TITLE
Add Vercel Speed Insights

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 - **Icons**: Iconoir (`iconoir-react`)
 - **Animation**: `motion` package
 - **Theming**: `next-themes` (system preference only)
-- **Analytics**: `@vercel/analytics`
+- **Analytics**: `@vercel/analytics`, `@vercel/speed-insights`
 - **Deployment**: Vercel
 
 ## Content Strategy

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@notionhq/client": "^5.13.0",
                 "@vercel/analytics": "^1.6.1",
+                "@vercel/speed-insights": "^2.0.0",
                 "clsx": "^2.1.1",
                 "iconoir-react": "^7.11.0",
                 "motion": "^12.35.2",
@@ -2757,6 +2758,44 @@
                     "optional": true
                 },
                 "next": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                },
+                "vue-router": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vercel/speed-insights": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+            "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "@sveltejs/kit": "^1 || ^2",
+                "next": ">= 13",
+                "nuxt": ">= 3",
+                "react": "^18 || ^19 || ^19.0.0-rc",
+                "svelte": ">= 4",
+                "vue": "^3",
+                "vue-router": "^4"
+            },
+            "peerDependenciesMeta": {
+                "@sveltejs/kit": {
+                    "optional": true
+                },
+                "next": {
+                    "optional": true
+                },
+                "nuxt": {
                     "optional": true
                 },
                 "react": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@notionhq/client": "^5.13.0",
         "@vercel/analytics": "^1.6.1",
+        "@vercel/speed-insights": "^2.0.0",
         "clsx": "^2.1.1",
         "iconoir-react": "^7.11.0",
         "motion": "^12.35.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import type { Metadata, Viewport } from 'next'
 import { Analytics } from '@vercel/analytics/next'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 import { Footer } from '@/components/footer'
 import { Nav } from '@/components/nav'
 import '../styles/globals.css'
@@ -61,6 +62,7 @@ export default function RootLayout({
                 </main>
                 <Footer />
                 <Analytics />
+                <SpeedInsights />
             </body>
         </html>
     )

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -112,7 +112,35 @@ export default function PrivacyPage() {
                 <br />
                 privacy@vercel.com
             </p>
-            <h2>3. Allgemeine Hinweise und Pflicht&shy;informationen</h2>
+            <h2>3. Analyse-Tools</h2>
+            <h3>Vercel Web Analytics &amp; Speed Insights</h3>{' '}
+            <p>
+                Diese Website nutzt Vercel Web Analytics und Vercel Speed
+                Insights, Dienste der Vercel Inc., 440 N Barranca Ave #4133,
+                Covina, CA 91723, USA, zur anonymen Messung von Seitenaufrufen
+                und Web-Performance-Kennzahlen (Core Web Vitals wie LCP, CLS,
+                INP).
+            </p>{' '}
+            <p>
+                Vercel setzt hierf&uuml;r keine Cookies und speichert keine
+                personenbezogenen Daten. IP-Adressen werden vor der Verarbeitung
+                anonymisiert und nicht dauerhaft gespeichert. Erhoben werden
+                ausschlie&szlig;lich aggregierte, nicht auf einzelne Personen
+                zur&uuml;ckf&uuml;hrbare technische Daten wie Seiten-URL,
+                Referrer, Ger&auml;tetyp, Browser und Performance-Metriken.
+            </p>{' '}
+            <p>
+                Die Nutzung erfolgt auf Grundlage unseres berechtigten
+                Interesses an einer statistisch fehlerfreien und performanten
+                Darstellung unseres Online-Angebots (Art. 6 Abs. 1 lit. f
+                DSGVO). Weitere Informationen finden Sie in der
+                Datenschutzerkl&auml;rung von Vercel unter{' '}
+                <a href="https://vercel.com/legal/privacy-policy">
+                    https://vercel.com/legal/privacy-policy
+                </a>
+                .
+            </p>
+            <h2>4. Allgemeine Hinweise und Pflicht&shy;informationen</h2>
             <h3>Datenschutz</h3>{' '}
             <p>
                 Die Betreiber dieser Seiten nehmen den Schutz Ihrer
@@ -331,7 +359,7 @@ export default function PrivacyPage() {
                 Europ&auml;ischen Union oder eines Mitgliedstaats verarbeitet
                 werden.
             </p>
-            <h2>4. Datenerfassung auf dieser Website</h2>
+            <h2>5. Datenerfassung auf dieser Website</h2>
             <h3>Anfrage per E-Mail, Telefon oder Telefax</h3>{' '}
             <p>
                 Wenn Sie uns per E-Mail, Telefon oder Telefax kontaktieren, wird


### PR DESCRIPTION
## Summary

- Mounts `<SpeedInsights />` from `@vercel/speed-insights/next` in the root layout alongside the existing `<Analytics />`
- Documents the new dependency in `docs/architecture.md`
- Adds a new section "3. Analyse-Tools" to the German Datenschutzerklärung disclosing both Vercel Web Analytics and Speed Insights (no cookies, anonymized, Art. 6 Abs. 1 lit. f DSGVO); renumbers the following sections
- No changes required to the imprint

## Test plan

- [x] `npm run dev` — verify `/_vercel/speed-insights/script.js` loads and no console errors
- [x] `npm run build` — passes typecheck/lint
- [x] After deploy: enable Speed Insights in the Vercel dashboard (Project → Speed Insights → Enable) and confirm data appears
- [ ] Review the new privacy section for wording


Made with [Cursor](https://cursor.com)